### PR TITLE
Added overload of SetFormUrlEncodedRequestBody

### DIFF
--- a/src/Cake.Http.Tests/Unit/HttpSettingsExtensionsTests.cs
+++ b/src/Cake.Http.Tests/Unit/HttpSettingsExtensionsTests.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Cake.Http.Tests.Unit
@@ -643,7 +641,7 @@ namespace Cake.Http.Tests.Unit
                 HttpSettings settings = new HttpSettings();
                 IDictionary<string, string> data = new Dictionary<string, string>
                 {
-                    ["Id"] =  "123",
+                    ["Id"] = "123",
                     ["LastName"] = "Test",
                     ["FirstName"] = "John"
                 };
@@ -658,7 +656,34 @@ namespace Cake.Http.Tests.Unit
                 Assert.True(settings.Headers.ContainsKey("Content-Type"));
                 Assert.Equal(settings.Headers["Content-Type"], "application/x-www-form-urlencoded");
 
-                Assert.NotNull(settings.RequestBody);                                
+                Assert.NotNull(settings.RequestBody);
+                Assert.Equal(expected, Encoding.UTF8.GetString(settings.RequestBody));
+            }
+
+            [Fact]
+            [Trait(Traits.TestCategory, TestCategories.Unit)]
+            public void Should_Set_Multiple_KeyValuePair_Request_Body_As_Url_Encoded()
+            {
+                //Given
+                HttpSettings settings = new HttpSettings();
+                var data = new []
+                {
+                    new KeyValuePair<string, string>("GroupId", "1"),
+                    new KeyValuePair<string, string>("GroupId", "2"),
+                    new KeyValuePair<string, string>("GroupId", "3")
+                };
+
+                //When
+                settings.SetFormUrlEncodedRequestBody(data);
+
+                //Then
+                var expected = "GroupId=1&GroupId=2&GroupId=3";
+
+                Assert.NotNull(settings.Headers);
+                Assert.True(settings.Headers.ContainsKey("Content-Type"));
+                Assert.Equal(settings.Headers["Content-Type"], "application/x-www-form-urlencoded");
+
+                Assert.NotNull(settings.RequestBody);
                 Assert.Equal(expected, Encoding.UTF8.GetString(settings.RequestBody));
             }
         }

--- a/src/Cake.Http/HttpSettingsExtensions.cs
+++ b/src/Cake.Http/HttpSettingsExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Text;
 
@@ -204,9 +205,23 @@ namespace Cake.Http
         /// Any existing content in the RequestBody is overriden.
         /// </summary>
         /// <param name="settings">The settings.</param>
-        /// <param name="data">Dictionary of data to url encode and append to the body.</param>
+        /// <param name="data">Dictionary of data to url encode and set to the body.</param>
         /// <returns>The same <see cref="HttpSettings"/> instance so that multiple calls can be chained.</returns>
-        public static HttpSettings SetFormUrlEncodedRequestBody(this HttpSettings settings, IDictionary<string, string> data)
+        public static HttpSettings SetFormUrlEncodedRequestBody(this HttpSettings settings,
+            IDictionary<string, string> data)
+            => SetFormUrlEncodedRequestBody(settings, data?.AsEnumerable());
+
+        /// <summary>
+        /// Sets the request body as form url encoded.
+        /// Only valid for Http Methods that allow a request body.
+        /// Any existing content in the RequestBody is overriden.
+        /// Accepts multiple parameters with the same key.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="data">Enumerable of <see cref="KeyValuePair{TKey,TValue}"/> of data to url encode and set to the body.</param>
+        /// <returns>The same <see cref="HttpSettings"/> instance so that multiple calls can be chained.</returns>
+        public static HttpSettings SetFormUrlEncodedRequestBody(this HttpSettings settings,
+            IEnumerable<KeyValuePair<string, string>> data)
         {
             if (settings == null)
                 throw new ArgumentNullException(nameof(settings));
@@ -219,6 +234,7 @@ namespace Cake.Http
 
             return settings;
         }
+
         private static void VerifyParameters(HttpSettings settings, string name, string value)
         {
             if (settings == null)


### PR DESCRIPTION
Added overload of `SetFormUrlEncodedRequestBody()` to allow multiple identical keys in encoded url form.