### PR TITLE
Support Client Certificate, editorconfig and minor cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# http://EditorConfig.org
+
+# This file is the top-most EditorConfig file
+root = true
+
+# All Files
+[*]
+charset = utf-8
+end_of_line = crlf
+indent_style = space
+indent_size = 4
+insert_final_newline = false
+trim_trailing_whitespace = true
+
+# Solution Files
+[*.sln]
+indent_style = tab
+
+# XML Project Files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2

--- a/src/Cake.Http.Tests/Cake.Http.Tests.csproj
+++ b/src/Cake.Http.Tests/Cake.Http.Tests.csproj
@@ -25,6 +25,7 @@
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.WebRequest" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">

--- a/src/Cake.Http.Tests/Fixtures/CakeContextFixture.cs
+++ b/src/Cake.Http.Tests/Fixtures/CakeContextFixture.cs
@@ -36,7 +36,6 @@ namespace Cake.Http.Tests.Fixtures
             ProcessRunner = Substitute.For<IProcessRunner>();
             Registry = Substitute.For<IRegistry>();
             Tools = Substitute.For<IToolLocator>();
-            
         }
 
         public void Dispose()

--- a/src/Cake.Http.Tests/Unit/CakeHttpClientHandlerTests.cs
+++ b/src/Cake.Http.Tests/Unit/CakeHttpClientHandlerTests.cs
@@ -1,0 +1,32 @@
+using System.Security.Cryptography.X509Certificates;
+using Cake.Core;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Http.Tests.Unit
+{
+    public class CakeHttpClientHandlerTests
+    {
+        [Fact]
+        public void Should_Add_Client_Certificates_From_Settings_To_Property()
+        {
+            //Given
+            var cakeContext = Substitute.For<ICakeContext>();
+            var settings = new HttpSettings
+            {
+                ClientCertificates =
+                {
+                    Substitute.For<X509Certificate2>(),
+                    Substitute.For<X509Certificate2>()
+                }
+            };
+
+            //When
+            var handler = new CakeHttpClientHandler(cakeContext, settings);
+
+            //Then
+            Assert.Equal(settings.ClientCertificates[0], handler.ClientCertificates[0]);
+            Assert.Equal(settings.ClientCertificates[1], handler.ClientCertificates[1]);
+        }
+    }
+}

--- a/src/Cake.Http.Tests/Unit/HttpClientAliasesTests.cs
+++ b/src/Cake.Http.Tests/Unit/HttpClientAliasesTests.cs
@@ -31,7 +31,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Or_Empty_Context_Parameter()
             {
-                //Given                
+                //Given 
                 ICakeContext context = null;
                 string address = RootAddress;
                 HttpSettings settings = new HttpSettings();
@@ -70,7 +70,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Settings_Parameter()
             {
-                //Given                
+                //Given
                 ICakeContext context = _Context;
                 string address = RootAddress;
                 HttpSettings settings = null;
@@ -86,7 +86,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Integration)]
             public void Should_Return_Json_Result()
             {
-                //Given                
+                //Given
                 ICakeContext context = _Context;
                 string address = $"{ RootAddress }/posts/1";
                 HttpSettings settings = new HttpSettings();
@@ -116,7 +116,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Or_Empty_Context_Parameter()
             {
-                //Given                
+                //Given
                 ICakeContext context = null;
                 string address = RootAddress;
                 HttpSettings settings = new HttpSettings();
@@ -155,7 +155,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Settings_Parameter()
             {
-                //Given                
+                //Given
                 ICakeContext context = _Context;
                 string address = RootAddress;
                 HttpSettings settings = null;
@@ -171,7 +171,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Integration)]
             public void Should_Post_And_Return_Json_Result()
             {
-                //Given                
+                //Given
                 var postData = "{\r\n    title: 'foo',\r\n    body: 'bar',\r\n    userId: 1\r\n  }";
 
                 ICakeContext context = _Context;
@@ -205,7 +205,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Or_Empty_Context_Parameter()
             {
-                //Given                
+                //Given
                 ICakeContext context = null;
                 string address = RootAddress;
                 HttpSettings settings = new HttpSettings();
@@ -244,7 +244,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Settings_Parameter()
             {
-                //Given                
+                //Given
                 ICakeContext context = _Context;
                 string address = RootAddress;
                 HttpSettings settings = null;
@@ -260,7 +260,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Integration)]
             public void Should_Put_And_Return_Json_Result()
             {
-                //Given                
+                //Given
                 var putData = "{\r\n    title: 'foo',\r\n    body: 'bar',\r\n    userId: 1\r\n  }";
 
                 ICakeContext context = _Context;
@@ -295,7 +295,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Or_Empty_Context_Parameter()
             {
-                //Given                
+                //Given
                 ICakeContext context = null;
                 string address = RootAddress;
                 HttpSettings settings = new HttpSettings();
@@ -334,7 +334,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Settings_Parameter()
             {
-                //Given                
+                //Given
                 ICakeContext context = _Context;
                 string address = RootAddress;
                 HttpSettings settings = null;
@@ -350,7 +350,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Integration)]
             public void Should_Patch_And_Return_Json_Result()
             {
-                //Given                
+                //Given
                 var patchData = "{\r\n    title: 'foo',\r\n    body: 'bar',\r\n    userId: 1\r\n  }";
 
                 ICakeContext context = _Context;
@@ -385,7 +385,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Or_Empty_Context_Parameter()
             {
-                //Given                
+                //Given
                 ICakeContext context = null;
                 string address = RootAddress;
                 HttpSettings settings = new HttpSettings();
@@ -424,7 +424,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Settings_Parameter()
             {
-                //Given                
+                //Given
                 ICakeContext context = _Context;
                 string address = RootAddress;
                 HttpSettings settings = null;
@@ -440,7 +440,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Integration)]
             public void Should_Delete_Return_Void()
             {
-                //Given                
+                //Given
                 ICakeContext context = _Context;
                 string address = $"{ RootAddress }/posts/1";
                 HttpSettings settings = new HttpSettings() { EnsureSuccessStatusCode = true };
@@ -467,7 +467,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Or_Empty_Context_Parameter()
             {
-                //Given                
+                //Given
                 ICakeContext context = null;
                 string address = RootAddress;
                 string httpMethod = "POST";
@@ -518,7 +518,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Settings_Parameter()
             {
-                //Given                
+                //Given
                 ICakeContext context = _Context;
                 HttpSettings settings = null;
                 string address = RootAddress;
@@ -535,12 +535,12 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Integration)]
             public void Should_Post_And_Return_Json_Result()
             {
-                //Given                
+                //Given
                 ICakeContext context = _Context;
                 HttpSettings settings = new HttpSettings();
                 string address = $"{ RootAddress }/posts";
                 string httpMethod = "POST";
-                
+
                 settings.SetRequestBody("{ \"title\": \"foo\", \"body\": \"bar\", \"userId\": 1}");
 
                 //When

--- a/src/Cake.Http.Tests/Unit/HttpSettingsExtensionsTests.cs
+++ b/src/Cake.Http.Tests/Unit/HttpSettingsExtensionsTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using NSubstitute;
 using Xunit;
 
 namespace Cake.Http.Tests.Unit
@@ -819,6 +821,77 @@ namespace Cake.Http.Tests.Unit
 
                 Assert.NotNull(settings.RequestBody);
                 Assert.Equal(expected, Encoding.UTF8.GetString(settings.RequestBody));
+            }
+        }
+
+        public sealed class TheAddClientCertificateMethod
+        {
+            [Fact]
+            [Trait(Traits.TestCategory, TestCategories.Unit)]
+            public void Should_Throw_On_Null_Argument()
+            {
+                //Given
+                var settings = new HttpSettings();
+                X509Certificate2[] clientCertificates = null;
+
+                //When
+                var nullRecord = Record.Exception(() => settings.UseClientCertificates(clientCertificates));
+
+                //Then
+                CakeAssert.IsArgumentNullException(nullRecord, nameof(clientCertificates));
+            }
+
+            [Fact]
+            [Trait(Traits.TestCategory, TestCategories.Unit)]
+            public void Should_Add_Client_Certificates_To_Settings()
+            {
+                //Given
+                var settings = new HttpSettings();
+                var firstCert = Substitute.For<X509Certificate2>();
+                var secondCert = Substitute.For<X509Certificate2>();
+
+                //When
+                settings.UseClientCertificates(firstCert, secondCert);
+
+                //Then
+                Assert.Contains(firstCert, settings.ClientCertificates);
+                Assert.Contains(secondCert, settings.ClientCertificates);
+            }
+
+            [Fact]
+            [Trait(Traits.TestCategory, TestCategories.Unit)]
+            public void Should_Add_Client_Certificates_As_Enumerable_To_Settings()
+            {
+                //Given
+                var settings = new HttpSettings();
+                var firstCert = Substitute.For<X509Certificate2>();
+                var secondCert = Substitute.For<X509Certificate2>();
+
+                //When
+                settings.UseClientCertificates(new List<X509Certificate2>{ firstCert, secondCert });
+
+                //Then
+                Assert.Contains(firstCert, settings.ClientCertificates);
+                Assert.Contains(secondCert, settings.ClientCertificates);
+            }
+
+            [Fact]
+            [Trait(Traits.TestCategory, TestCategories.Unit)]
+            public void Should_Accumulate_Certificates_From_Multiple_Calls()
+            {
+                //Given
+                var settings = new HttpSettings();
+                var firstCert = Substitute.For<X509Certificate2>();
+                var secondCert = Substitute.For<X509Certificate2>();
+
+                //When
+                settings
+                    .UseClientCertificates(firstCert)
+                    .UseClientCertificates(secondCert);
+
+                //Then
+                Assert.Contains(firstCert, settings.ClientCertificates);
+                Assert.Contains(secondCert, settings.ClientCertificates);
             }
         }
     }

--- a/src/Cake.Http.Tests/Unit/HttpSettingsExtensionsTests.cs
+++ b/src/Cake.Http.Tests/Unit/HttpSettingsExtensionsTests.cs
@@ -13,7 +13,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Settings_Parameter()
             {
-                //Given                
+                //Given
                 HttpSettings settings = null;
                 string name = "Content-Type";
                 string value = "applicaion/json";
@@ -29,7 +29,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Or_Empty_Name_Parameter()
             {
-                //Given                
+                //Given
                 HttpSettings settings = new HttpSettings();
                 string value = "applicaion/json";
 
@@ -48,7 +48,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Or_Empty_Value_Parameter()
             {
-                //Given                
+                //Given
                 HttpSettings settings = new HttpSettings();
                 string name = "Content-Type";
 
@@ -107,7 +107,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Settings_Parameter()
             {
-                //Given                
+                //Given
                 HttpSettings settings = null;
                 string name = "sessionid";
                 string value = "1BA9481B-74C1-42B3-A1B9-0B914BAE0F05";
@@ -123,7 +123,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Or_Empty_Name_Parameter()
             {
-                //Given                
+                //Given
                 HttpSettings settings = new HttpSettings();
                 string name = null;
                 string value = "1BA9481B-74C1-42B3-A1B9-0B914BAE0F05";
@@ -146,7 +146,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Or_Empty_Value_Parameter()
             {
-                //Given                
+                //Given
                 HttpSettings settings = new HttpSettings();
                 string name = "sessionid";
                 string value = null;
@@ -190,7 +190,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Or_Empty_Schema_Parameter()
             {
-                //Given                
+                //Given
                 HttpSettings settings = new HttpSettings();
                 string parameter = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0b3B0YWwuY29tIiwiZXhwIjoxNDI2NDIwODAwLCJodHRwOi8vdG9wdGFsLmNvbS9qd3RfY2xhaW1zL2lzX2FkbWluIjp0cnVlLCJjb21wYW55IjoiVG9wdGFsIiwiYXdlc29tZSI6dHJ1ZX0.yRQYnWzskCZUxPwaQupWkiUzKELZ49eM7oWxAQK_ZXw";
 
@@ -209,7 +209,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Or_Empty_Parameter_Parameter()
             {
-                //Given                
+                //Given
                 HttpSettings settings = new HttpSettings();
                 string schema = "Bearer";
 
@@ -251,7 +251,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Settings_Parameter()
             {
-                //Given                
+                //Given
                 HttpSettings settings = null;
 
                 //When
@@ -282,7 +282,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Or_Empty_UserName_Parameter()
             {
-                //Given                
+                //Given
                 HttpSettings settings = new HttpSettings();
                 string userName = null;
                 string password = "tiger";
@@ -305,7 +305,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Or_Empty_Password_Parameter()
             {
-                //Given                
+                //Given
                 HttpSettings settings = new HttpSettings();
                 string userName = "scott";
                 string password = null;
@@ -351,7 +351,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Or_Empty_Token_Parameter()
             {
-                //Given                
+                //Given
                 HttpSettings settings = new HttpSettings();
                 string token = null;
 
@@ -395,7 +395,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Or_Empty_ContentType_Parameter()
             {
-                //Given                
+                //Given
                 HttpSettings settings = new HttpSettings();
                 string contentType = null;
 
@@ -437,7 +437,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Or_Empty_Accept_Parameter()
             {
-                //Given                
+                //Given
                 HttpSettings settings = new HttpSettings();
                 string accept = null;
 
@@ -498,7 +498,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Or_Empty_Url_Parameter()
             {
-                //Given                
+                //Given
                 HttpSettings settings = new HttpSettings();
                 string url = null;
 
@@ -540,7 +540,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Or_Empty_Url_Parameter()
             {
-                //Given                
+                //Given
                 HttpSettings settings = new HttpSettings();
                 string url = null;
 
@@ -582,7 +582,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Settings_Parameter()
             {
-                //Given                
+                //Given
                 HttpSettings settings = null;
                 string requestBody = "{ \"id\":0, \"name\": \"testing\"}";
 
@@ -597,7 +597,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Or_Empty_RequestBody_Parameter()
             {
-                //Given                
+                //Given 
                 HttpSettings settings = new HttpSettings();
                 string requestBody = null;
 
@@ -638,7 +638,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Settings_Parameter()
             {
-                //Given                
+                //Given
                 HttpSettings settings = null;
                 BodyModel model = new BodyModel { Id = 1234567, Active = true, name = "Rob Test" };          
 
@@ -653,7 +653,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Or_Empty_Data_Parameter()
             {
-                //Given                
+                //Given
                 HttpSettings settings = new HttpSettings();
                 BodyModel data = null;
 
@@ -741,7 +741,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Settings_Parameter()
             {
-                //Given                
+                //Given
                 HttpSettings settings = null;
                 var data = new Dictionary<string, string>();
 
@@ -756,7 +756,7 @@ namespace Cake.Http.Tests.Unit
             [Trait(Traits.TestCategory, TestCategories.Unit)]
             public void Should_Throw_On_Null_Or_Empty_Data_Parameter()
             {
-                //Given                
+                //Given
                 HttpSettings settings = new HttpSettings();
                 IDictionary<string, string> data = null;
 

--- a/src/Cake.Http/Cake.Http.csproj
+++ b/src/Cake.Http/Cake.Http.csproj
@@ -5,12 +5,13 @@
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.6|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;NETSTANDARD1_6</DefineConstants>
+  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard1.6'">
+    <DefineConstants>NETSTANDARD1_6</DefineConstants>
     <WarningLevel>0</WarningLevel>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard1.6|AnyCPU'">
+  <PropertyGroup Condition="'$(TargetFramework)'=='net46'">
+    <DefineConstants>net46</DefineConstants>
     <WarningLevel>0</WarningLevel>
   </PropertyGroup>
 

--- a/src/Cake.Http/Cake.Http.csproj
+++ b/src/Cake.Http/Cake.Http.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.WebRequest" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">

--- a/src/Cake.Http/CakeHttpClientHandler.cs
+++ b/src/Cake.Http/CakeHttpClientHandler.cs
@@ -85,11 +85,11 @@ namespace Cake.Http
                 {
                     response.EnsureSuccessStatusCode();
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     // Only throw exception on when Non-Success Status Code
                     if (_Settings.ThrowExceptionOnNonSuccessStatusCode)
-                        throw ex;
+                        throw;
                 }
             }
 

--- a/src/Cake.Http/CakeHttpClientHandler.cs
+++ b/src/Cake.Http/CakeHttpClientHandler.cs
@@ -15,8 +15,7 @@ namespace Cake.Http
 
 #if net46
     public class CakeHttpClientHandler : WebRequestHandler
-#endif
-#if NETSTANDARD1_6
+#else
     public class CakeHttpClientHandler : HttpClientHandler
 #endif
   {

--- a/src/Cake.Http/CakeHttpClientHandler.cs
+++ b/src/Cake.Http/CakeHttpClientHandler.cs
@@ -12,28 +12,30 @@ namespace Cake.Http
     /// <summary>
     /// Custom HTTP Handler to delegate the processing of HTTP requests and extending it.
     /// </summary>
-    public class CakeHttpClientHandler : DelegatingHandler
-    {
-        private readonly HttpSettings _Settings;
-        private readonly ICakeContext _Context;
 
-        /// <summary>
-        /// Custom HTTP Handler to delegate the processing of HTTP requests and extending it.
-        /// </summary>
-        /// <param name="context">Cake Context the request is geting </param>
-        /// <param name="settings">HttpSettings to apply to the inner handler</param>
-        public CakeHttpClientHandler(ICakeContext context, HttpSettings settings)
+#if net46
+    public class CakeHttpClientHandler : WebRequestHandler
+#endif
+#if NETSTANDARD1_6
+    public class CakeHttpClientHandler : HttpClientHandler
+#endif
+  {
+    private readonly HttpSettings _Settings;
+    private readonly ICakeContext _Context;
+
+    /// <summary>
+    /// Custom HTTP Handler to delegate the processing of HTTP requests and extending it.
+    /// </summary>
+    /// <param name="context">Cake Context the request is geting </param>
+    /// <param name="settings">HttpSettings to apply to the inner handler</param>
+    public CakeHttpClientHandler(ICakeContext context, HttpSettings settings)
         {
-            if (context == null)
-                throw new ArgumentNullException(nameof(context));
+            _Context = context ?? throw new ArgumentNullException(nameof(context));
+            _Settings = settings ?? throw new ArgumentException(nameof(settings));
 
-            if (settings == null)
-                throw new ArgumentException(nameof(settings));
+            UseDefaultCredentials = settings.UseDefaultCredentials;
+            UseCookies = false;
 
-            _Context = context;
-            _Settings = settings;
-
-            InnerHandler = GetClientHandler();
         }
 
         /// <summary>
@@ -94,21 +96,6 @@ namespace Cake.Http
             return response;
         }
 
-        /// <summary>
-        /// Gets the client Handler
-        /// </summary>
-        /// <returns></returns>
-        private HttpClientHandler GetClientHandler()
-        {
-            var handler = new HttpClientHandler()
-            {
-                UseDefaultCredentials = _Settings.UseDefaultCredentials,
-                UseCookies = false
-            };
-
-            return handler;
-        }
-        
         /// <summary>
         /// Appends headers to HttpRequestMessage before sending the 
         /// </summary>

--- a/src/Cake.Http/CakeHttpClientHandler.cs
+++ b/src/Cake.Http/CakeHttpClientHandler.cs
@@ -102,7 +102,7 @@ namespace Cake.Http
         {
             var handler = new HttpClientHandler()
             {
-                UseDefaultCredentials = _Settings.UseDefaultCredentials,                
+                UseDefaultCredentials = _Settings.UseDefaultCredentials,
                 UseCookies = false
             };
 

--- a/src/Cake.Http/CakeHttpClientHandler.cs
+++ b/src/Cake.Http/CakeHttpClientHandler.cs
@@ -35,6 +35,10 @@ namespace Cake.Http
             UseDefaultCredentials = settings.UseDefaultCredentials;
             UseCookies = false;
 
+            foreach (var clientCertificate in settings.ClientCertificates)
+            {
+                ClientCertificates.Add(clientCertificate);
+            }
         }
 
         /// <summary>

--- a/src/Cake.Http/HttpSettings.cs
+++ b/src/Cake.Http/HttpSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
 
 namespace Cake.Http
 {
@@ -14,6 +15,7 @@ namespace Cake.Http
         {
             Headers = new Dictionary<string, string>();
             Cookies = new Dictionary<string, string>();
+            ClientCertificates = new List<X509Certificate2>();
         }
 
         /// <summary>
@@ -50,5 +52,10 @@ namespace Cake.Http
         /// This is used in conjunction with EnsureSuccessStatusCode.
         /// </summary>
         public bool ThrowExceptionOnNonSuccessStatusCode { get; set; }
+
+        /// <summary>
+        /// List of Client Certificates to be enclosed with the http request.
+        /// </summary>
+        public IList<X509Certificate2> ClientCertificates { get; set; }
     }
 }

--- a/src/Cake.Http/HttpSettingsExtensions.cs
+++ b/src/Cake.Http/HttpSettingsExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 
 namespace Cake.Http
@@ -276,6 +277,36 @@ namespace Cake.Http
 
             return settings;
         }
+
+          /// <summary>
+          ///  Adds client certificate(s) to the http handler.
+          /// </summary>
+          /// <param name="settings">The settings.</param>
+          /// <param name="clientCertificates">Client certificates to include in requests.</param>
+          /// <returns></returns>
+          public static HttpSettings UseClientCertificates(this HttpSettings settings, params X509Certificate2[] clientCertificates)
+          {
+              return settings.UseClientCertificates((IEnumerable<X509Certificate2>)clientCertificates);
+          }
+
+          /// <summary>
+          ///  Adds client certificate(s) to the http handler.
+          /// </summary>
+          /// <param name="settings">The settings.</param>
+          /// <param name="clientCertificates">Client certificates to include in requests.</param>
+          /// <returns></returns>
+          public static HttpSettings UseClientCertificates(this HttpSettings settings, IEnumerable<X509Certificate2> clientCertificates)
+          {
+            if (clientCertificates == null)
+                throw new ArgumentNullException(nameof(clientCertificates));
+
+            foreach (var clientCertificate in clientCertificates)
+            {
+                settings.ClientCertificates.Add(clientCertificate);
+            }
+
+            return settings;
+          }
 
         private static void VerifyParameters(HttpSettings settings, string name, string value)
         {

--- a/src/Cake.Http/HttpSettingsExtensions.cs
+++ b/src/Cake.Http/HttpSettingsExtensions.cs
@@ -260,7 +260,6 @@ namespace Cake.Http
             return settings;
         }
 
-
         /// <summary>
         /// Sets the EnsureSuccessStatusCode to true. This makes the httpclient throw an error if it does not return a 200 range status.
         /// </summary>


### PR DESCRIPTION
This PR fixes #41 as well as fixes #42 (the latter in order for me to contribute without changing my personal IDE preferences).

To support `netstandard1.6` and `net46`  I had to add compiler directives to the `CakeHttpClientHandler` (described more closely in #41).

Unit tests for the new extension method `AddClientCertificates` are added. However, I coundn't figure out a good test for making sure that the request was posted with client certificates (jsonplaceholder didn't have any endpoints for this). Instead I added a test that verified that the supplied client certificates ended up in the HttpHandler's `ClientCertificate` property. The fact that the alias is a static class and that the http client is created inside it makes it difficult to mock etc - let me know if you can think of a test case that verifies that the client cert is actually sent!

This PR also contains some minor cleanup:
* Removing trailing whiltespaces
* Removing extra linebreak(s)
* Implicit re-throw of exception
* Simplify property group condition in csproj
* Use [throw expression](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7#throw-expressions)

Let me know what you think!