### PR TITLE
(#49) Upgraded Cake to 0.28.0 and removed .NET46 from TargetFramework

### DIFF
--- a/nuspec/nuget/Cake.Http.nuspec
+++ b/nuspec/nuget/Cake.Http.nuspec
@@ -17,10 +17,6 @@
     <tags>cake script build httpclient web</tags>
   </metadata>
   <files>
-    <file src="net46/Cake.Http.dll" target="lib/net46" />
-    <file src="net46/Cake.Http.pdb" target="lib/net46" />
-    <file src="net46/Cake.Http.xml" target="lib/net46" />
-
     <file src="netstandard2.0/Cake.Http.dll" target="lib/netstandard2.0" />
     <file src="netstandard2.0/Cake.Http.pdb" target="lib/netstandard2.0" />
     <file src="netstandard2.0/Cake.Http.xml" target="lib/netstandard2.0" />

--- a/src/Cake.Http.Tests/Cake.Http.Tests.csproj
+++ b/src/Cake.Http.Tests/Cake.Http.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>    
-    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,6 +9,7 @@
     <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Cake.Core" Version="0.28.0"/>
   </ItemGroup>
 
   <ItemGroup>
@@ -21,11 +22,6 @@
 
   <ItemGroup>
     <Folder Include="Properties\" />
-  </ItemGroup>
-  
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.WebRequest" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/Cake.Http.Tests/Fixtures/CakeContextFixture.cs
+++ b/src/Cake.Http.Tests/Fixtures/CakeContextFixture.cs
@@ -19,6 +19,7 @@ namespace Cake.Http.Tests.Fixtures
         public IProcessRunner ProcessRunner { get; set; }
         public IRegistry Registry { get; set; }
         public IToolLocator Tools { get; set; }
+        public ICakeDataResolver Data { get; set; }
 
         public CakeContextFixture()
         {
@@ -36,6 +37,7 @@ namespace Cake.Http.Tests.Fixtures
             ProcessRunner = Substitute.For<IProcessRunner>();
             Registry = Substitute.For<IRegistry>();
             Tools = Substitute.For<IToolLocator>();
+            Data = Substitute.For<ICakeDataResolver>();
         }
 
         public void Dispose()

--- a/src/Cake.Http/Cake.Http.csproj
+++ b/src/Cake.Http/Cake.Http.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
-	<GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
@@ -10,18 +10,10 @@
     <WarningLevel>0</WarningLevel>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)'=='net46'">
-    <DefineConstants>net46</DefineConstants>
-    <WarningLevel>0</WarningLevel>
-  </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.26.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.WebRequest" />
+    <PackageReference Include="Cake.Core" Version="0.28.0">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">


### PR DESCRIPTION
Dear maintainers,

Thank you for this package!
This PR fixes #49 . Please let me know if I should change anything. (I'm a bit hesitant to drop .NET4.6 to be fair, despite I see the point https://github.com/cake-contrib/Home/issues/49)