### PR TITLE
Fix content type in documentation's examples

### DIFF
--- a/src/Cake.Http/HttpClientAliases.cs
+++ b/src/Cake.Http/HttpClientAliases.cs
@@ -1,4 +1,4 @@
-﻿using Cake.Core;
+using Cake.Core;
 using Cake.Core.Annotations;
 using System;
 using System.Net.Http;
@@ -189,7 +189,7 @@ namespace Cake.Http
         ///         string responseBody = HttpPost("https://www.google.com", settings =>
         ///         {
         ///            settings.UseBearerAuthorization("1af538baa9045a84c0e889f672baf83ff24")
-        ///                    .SetContentType("appliication/json")
+        ///                    .SetContentType("application/json")
         ///                    .SetRequestBody("{ \"id\": 123, \"name\": \"Test Test\" }");
         ///         });
         /// </code>
@@ -298,7 +298,7 @@ namespace Cake.Http
         ///         string responseBody = HttpPut("https://www.google.com/1", settings =>
         ///         {
         ///            settings.UseBearerAuthorization("1af538baa9045a84c0e889f672baf83ff24")
-        ///                    .SetContentType("appliication/json")
+        ///                    .SetContentType("application/json")
         ///                    .SetRequestBody("{ \"id\": 123, \"name\": \"Test Test\" }");
         ///         });
         /// </code>
@@ -409,7 +409,7 @@ namespace Cake.Http
         ///         string responseBody = HttpPatch("https://www.google.com/1", settings =>
         ///         {
         ///            settings.UseBearerAuthorization("1af538baa9045a84c0e889f672baf83ff24")
-        ///                    .SetContentType("appliication/json")
+        ///                    .SetContentType("application/json")
         ///                    .SetRequestBody("{ \"id\": 123, \"name\": \"Test Test\" }");
         ///         });
         /// </code>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updating XML comments with correct content type.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Spent some time trying to figure out why my request is not being sent. Turns out it was due to copy-past from [docs](https://cakebuild.net/api/Cake.Http/HttpClientAliases/ACAEB025).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
