### PR TITLE
Fixes Typo in HttpClient Examples

### DIFF
--- a/src/Cake.Http/HttpClientAliases.cs
+++ b/src/Cake.Http/HttpClientAliases.cs
@@ -79,7 +79,7 @@ namespace Cake.Http
         ///        var responseBody = HttpGet("https://www.google.com", settings =>
         ///        {
         ///            settings.UseBearerAuthorization("1af538baa9045a84c0e889f672baf83ff24")
-        ///                    .SetNoCeche()
+        ///                    .SetNoCache()
         ///                    .AppendHeader("Connection", "keep-alive");
         ///        });
         /// </code>

--- a/src/Cake.Http/HttpClientAsyncAliases.cs
+++ b/src/Cake.Http/HttpClientAsyncAliases.cs
@@ -79,7 +79,7 @@ namespace Cake.Http
         ///        var responseBody = await HttpGetAsync("https://www.google.com", settings =>
         ///        {
         ///            settings.UseBearerAuthorization("1af538baa9045a84c0e889f672baf83ff24")
-        ///                    .SetNoCeche()
+        ///                    .SetNoCache()
         ///                    .AppendHeader("Connection", "keep-alive");
         ///        });
         /// </code>

--- a/src/Cake.Http/HttpSettingsExtensions.cs
+++ b/src/Cake.Http/HttpSettingsExtensions.cs
@@ -211,7 +211,7 @@ namespace Cake.Http
         /// <summary>
         /// Sets the request body as form url encoded.
         /// Only valid for Http Methods that allow a request body.
-        /// Any existing content in the RequestBody is overriden.
+        /// Any existing content in the RequestBody is overridden.
         /// </summary>
         /// <param name="settings">The settings.</param>
         /// <param name="data">Dictionary of data to url encode and set to the body.</param>
@@ -222,7 +222,7 @@ namespace Cake.Http
         /// <summary>
         /// Sets the request body as form url encoded.
         /// Only valid for Http Methods that allow a request body.
-        /// Any existing content in the RequestBody is overriden.
+        /// Any existing content in the RequestBody is overridden.
         /// Accepts multiple parameters with the same key.
         /// </summary>
         /// <param name="settings">The settings.</param>
@@ -245,7 +245,7 @@ namespace Cake.Http
         /// <summary>
         /// Sets the request body as form url encoded.
         /// Only valid for Http Methods that allow a request body.
-        /// Any existing content in the RequestBody is overriden.
+        /// Any existing content in the RequestBody is overridden.
         /// Accepts multiple parameters with the same key.
         ///This can be used to post files to a remote URL
         /// </summary>
@@ -282,7 +282,7 @@ namespace Cake.Http
         /// <summary>
         /// Sets the request body as form url encoded.
         /// Only valid for Http Methods that allow a request body.
-        /// Any existing content in the RequestBody is overriden.
+        /// Any existing content in the RequestBody is overridden.
         /// Accepts multiple parameters with the same key.
         /// This can be used to post files to a remote URL
         /// </summary>


### PR DESCRIPTION
## Description

Bit of a follow-up to [this commit](https://github.com/cake-contrib/Cake.Http/commit/97c1493d683e4e26443a164099da6ae3e85d501e), but fixes any additional instances of the malformed setting example `SetNoCeche` in the code help / examples.

Now also replaces "overriden" with "overridden".

## Related Issue
I'm happy to create an issue for this, but feel it may be acceptable without one.

## Motivation and Context
Simple typo found on Cakebuild.net examples.

## How Has This Been Tested?
I haven't tested this. Sorry.

## Types of changes
- ~[ ] Bug fix (non-breaking change which fixes an issue)~
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- ~[ ] I have added tests to cover my changes.~
- ~[ ] All new and existing tests passed.~
